### PR TITLE
mailmap: add Kaelin Laundry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,2 @@
 <jwilk@jwilk.net> <ubanus@users.sf.net>
+Kaelin Laundry <wasabifan@outlook.com>


### PR DESCRIPTION
@WasabiFan authored commits under two different names, which breaks `git shortlog`.

Before:
```console
$ git shortlog -s -e --author=wasabifan
     1  Kaelin Laundry <wasabifan@outlook.com>
     1  Wasabi Fan <wasabifan@outlook.com>
```
After updating `.mailmap`:
```console
$ git shortlog -s -e --author=wasabifan
     2  Kaelin Laundry <wasabifan@outlook.com>
```

@WasabiFan, is that okay with you?